### PR TITLE
Add dependency on Test::CPAN::Meta::JSON to make sure he is installed

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -5,3 +5,6 @@ copyright_holder    = Mike Doherty
 copyright_year      = 2011
 
 [@Author::DOHERTY]
+
+[Prereqs / RuntimeRequires]
+Test::CPAN::Meta::JSON = 0


### PR DESCRIPTION
Hi there,

I'm not sure if this is something that you missed or something that you specifically do not want, but I use this plugin on my PluginBundle, and I've added this dependency to my own dist.ini to solve it in the meantime, but I think it would be better for all users of the plugin to move the dependency upstream.

Again, maybe there is a good reason not to do this, but in case you have none, please accept this patch :).

Best regards,
