### PR TITLE
Hard dependency on Test::CPAN::Meta::JSON

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,8 @@ Revision history for Perl module {{$dist->name}}
     * Don't silently skip the test if Test::CPAN::Meta::JSON is not installed
     * Inject develop/requires dependency on Test::CPAN::Meta::JSON into the
       dist using the plugin
+    * Bump Test::CPAN::Meta::JSON dependency to 0.16 (latest) that has fixes
+      for the license
 
 0.003     2011-04-19
     * File::Path 2.08 needed for remove_tree()

--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 Revision history for Perl module {{$dist->name}}
 
 {{$NEXT}}
+    * Don't silently skip the test if Test::CPAN::Meta::JSON is not installed
+    * Inject develop/requires dependency on Test::CPAN::Meta::JSON into the
+      dist using the plugin
 
 0.003     2011-04-19
     * File::Path 2.08 needed for remove_tree()

--- a/dist.ini
+++ b/dist.ini
@@ -4,6 +4,8 @@ license             = Perl_5
 copyright_holder    = Mike Doherty
 copyright_year      = 2011
 
+[Bootstrap::lib]
+
 [@Author::DOHERTY]
 
 [Prereqs / RuntimeRequires]

--- a/dist.ini
+++ b/dist.ini
@@ -9,4 +9,4 @@ copyright_year      = 2011
 [@Author::DOHERTY]
 
 [Prereqs / RuntimeRequires]
-Test::CPAN::Meta::JSON = 0
+Test::CPAN::Meta::JSON = 0.16

--- a/lib/Dist/Zilla/Plugin/Test/CPAN/Meta/JSON.pm
+++ b/lib/Dist/Zilla/Plugin/Test/CPAN/Meta/JSON.pm
@@ -57,7 +57,7 @@ sub register_prereqs {
       type  => 'requires',
       phase => 'develop',
     },
-    'Test::CPAN::Meta::JSON' => '0',
+    'Test::CPAN::Meta::JSON' => '0.16',
   );
 }
 

--- a/lib/Dist/Zilla/Plugin/Test/CPAN/Meta/JSON.pm
+++ b/lib/Dist/Zilla/Plugin/Test/CPAN/Meta/JSON.pm
@@ -8,6 +8,7 @@ use Moose;
 use Moose::Autobox;
 extends 'Dist::Zilla::Plugin::InlineFiles';
 with 'Dist::Zilla::Role::FilePruner';
+with 'Dist::Zilla::Role::PrereqSource';
 
 =head1 SYNOPSIS
 
@@ -46,6 +47,21 @@ sub prune_files {
     return;
 }
 
+# Register the release test prereq as a "develop requires"
+# so it will be listed in "dzil listdeps --author"
+sub register_prereqs {
+  my ($self) = @_;
+
+  $self->zilla->register_prereqs(
+    {
+      type  => 'requires',
+      phase => 'develop',
+    },
+    'Test::CPAN::Meta::JSON' => '0',
+  );
+}
+
+
 __PACKAGE__->meta->make_immutable;
 no Moose;
 
@@ -63,7 +79,5 @@ __DATA__
 __[ xt/release/meta-json.t ]__
 #!perl
 
-use Test::More;
-eval 'use Test::CPAN::Meta::JSON';
-plan skip_all => 'Test::CPAN::Meta::JSON required for testing META.json' if $@;
+use Test::CPAN::Meta::JSON;
 meta_json_ok();


### PR DESCRIPTION
Before this patch, the test is (almost) silently skipped if, for some reason, Test::CPAN::Meta::JSON is not in @INC.
Instead the release test will now fail hard.
In addition the dependency on Test::CPAN::Meta::JSON is injected in the distribution as a develop/requires.